### PR TITLE
Remove quotes from arguments in usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,21 @@ Usage
 
 ```hcl
 module "bastion" {
-  "source" = "Guimove/bastion/aws"
-  "bucket_name" = "my_famous_bucket_name"
-  "region" = "eu-west-1"
-  "vpc_id" = "my_vpc_id"
-  "is_lb_private" = "true|false"
-  "bastion_host_key_pair" = "my_key_pair"
-  "create_dns_record" = "true|false"
-  "hosted_zone_id" = "my.hosted.zone.name."
-  "bastion_record_name" = "bastion.my.hosted.zone.name."
-  "bastion_iam_policy_name" = "myBastionHostPolicy"
-  "elb_subnets" = [
+  source = "Guimove/bastion/aws"
+  bucket_name = "my_famous_bucket_name"
+  region = "eu-west-1"
+  vpc_id = "my_vpc_id"
+  is_lb_private = "true|false"
+  bastion_host_key_pair = "my_key_pair"
+  create_dns_record = "true|false"
+  hosted_zone_id = "my.hosted.zone.name."
+  bastion_record_name = "bastion.my.hosted.zone.name."
+  bastion_iam_policy_name = "myBastionHostPolicy"
+  elb_subnets = [
     "subnet-id1a",
     "subnet-id1b"
   ]
-  "auto_scaling_group_subnets" = [
+  auto_scaling_group_subnets = [
     "subnet-id1a",
     "subnet-id1b"
   ]


### PR DESCRIPTION
Remove quotes from arguments in usage section to align with correct syntax.